### PR TITLE
lv_conf: Set refresh rate to 16ms and disable printing logs

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -26,7 +26,7 @@
  *====================*/
 
 /*Color depth: 1 (I1), 8 (L8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888)*/
-#define LV_COLOR_DEPTH 16
+#define LV_COLOR_DEPTH 32
 
 /*=========================
    STDLIB WRAPPER SETTINGS

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -698,7 +698,7 @@
 /*File system interfaces for common APIs */
 
 /*Setting a default driver letter allows skipping the driver prefix in filepaths*/
-#define LV_FS_DEFAULT_DRIVE_LETTER 'A'
+#define LV_FS_DEFAULT_DRIVER_LETTER 'A'
 
 /*API for fopen, fread, etc*/
 #define LV_USE_FS_STDIO 1

--- a/main.c
+++ b/main.c
@@ -192,6 +192,7 @@ int main(int argc, char **argv)
     lv_linux_disp_init();
 
     /*Create a Demo*/
+    lv_sysmon_hide_performance(NULL);
     lv_demo_high_res_api_example("/usr/share/ti-lvgl-demo/assets/", "/usr/share/ti-lvgl-demo/assets/img_lv_demo_high_res_ti_logo.png", "/usr/share/ti-lvgl-demo/slides");
 
     lv_linux_run_loop();


### PR DESCRIPTION
Presently the refresh rate is 33ms. Set this to 16ms. Logs are being printed to the console while running this demo, presently. Disable this.